### PR TITLE
Fix: action status

### DIFF
--- a/src/cytomat/status.py
+++ b/src/cytomat/status.py
@@ -129,7 +129,6 @@ class ActionStatus(NamedTuple):
     def from_hex_string(cls, hex_byte: str) -> ActionStatus:
         """Create an instance from the hex string (e.g. ``'F1'``)"""
         num = int(hex_byte, base=16)
-        print(f"ActionStatus: decode num={num}, hex=0x{hex_byte}, binary=0b{num:08b}")
         action_target = enum_to_dict(ActionTarget)[(num & 0b11100000) >> 5]
         action_type = enum_to_dict(ActionType)[num & 0b00011111]
         return ActionStatus(action_type, action_target)


### PR DESCRIPTION
a couple of bugs
1. the target is actually the higher bit group
  ![image](https://github.com/user-attachments/assets/ad651ebf-cf23-4edf-9049-c095bbd8fa2b)
2. apparently two binary values were missing from the action type. They are not in the manual though!
  1. `0x00`: seems to be set when no action happens, idle
  2. `0x1c`: unknown, but during movement actions it seldomly gets set when fetching with high frequency.