### PR TITLE
Fix: mismatching return codes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "open-cytomat"
-version = "0.3.2"
+version = "0.3.3"
 description = ""
 authors = [
     "Niklas Mertsch <niklas.mertsch@stud.uni-goettingen.de>",

--- a/src/cytomat/serial_port.py
+++ b/src/cytomat/serial_port.py
@@ -1,5 +1,4 @@
 import re
-import traceback
 from threading import Lock
 
 from serial import Serial
@@ -163,9 +162,7 @@ class SerialPort:
         try:
             response = self.check_prefix_and_strip(self.communicate(command), expected_prefix=command[3:5])
         except UnexpectedResponse as e:
-            print(f"Unexpected response while checking status: {e}")
-            traceback.print_exc()
-            print("Trying again")
+            print(f"Unexpected response while checking status: {e}. Trying again.")
             response = self.check_prefix_and_strip(self.communicate(command), expected_prefix=command[3:5])
 
         return response

--- a/src/cytomat/serial_port.py
+++ b/src/cytomat/serial_port.py
@@ -1,4 +1,5 @@
 import re
+import traceback
 from threading import Lock
 
 from serial import Serial
@@ -159,6 +160,12 @@ class SerialPort:
         if not re.fullmatch("ch:[a-z]{2}.*", command):
             raise InvalidCommand(f"Expected command like 'ch:xx' or 'ch:xx ...', got '{command}'")
 
-        return self.check_prefix_and_strip(
-            self.communicate(command), expected_prefix=command[3:5]
-        )
+        try:
+            response = self.check_prefix_and_strip(self.communicate(command), expected_prefix=command[3:5])
+        except UnexpectedResponse as e:
+            print(f"Unexpected response while checking status: {e}")
+            traceback.print_exc()
+            print("Trying again")
+            response = self.check_prefix_and_strip(self.communicate(command), expected_prefix=command[3:5])
+
+        return response

--- a/src/cytomat/serial_port.py
+++ b/src/cytomat/serial_port.py
@@ -25,7 +25,9 @@ class SerialPort:
         timeout: float, seconds
             A :class:`TimeoutError` will be raised of read or write operations took longer than this duration
         """
-        self.port = Serial(port, baudrate=9600, bytesize=8, stopbits=1, parity=PARITY_NONE, timeout=timeout, write_timeout=timeout)
+        self.port = Serial(
+            port, baudrate=9600, bytesize=8, stopbits=1, parity=PARITY_NONE, timeout=timeout, write_timeout=timeout
+        )
         self.lock = Lock()
         self.timeout = timeout
 
@@ -58,9 +60,7 @@ class SerialPort:
         """
         with lock_threading_lock(self.lock, timeout=self.timeout):
             if self.port.in_waiting:
-                raise SerialCommunicationError(
-                    "There were unread bytes in the input buffer"
-                )
+                raise SerialCommunicationError("There were unread bytes in the input buffer")
 
             raw_command: bytes = command.encode("ascii") + b"\r"
             raw_response: bytes = b""
@@ -100,9 +100,7 @@ class SerialPort:
         """
         if response.startswith(expected_prefix):
             return response[len(expected_prefix) :].strip()
-        raise UnexpectedResponse(
-            f"Expected response prefix '{expected_prefix}', got response '{response}'"
-        )
+        raise UnexpectedResponse(f"Expected response prefix '{expected_prefix}', got response '{response}'")
 
     def issue_action_command(self, command: str) -> PlateShuttleSystemStatus:
         """
@@ -128,16 +126,10 @@ class SerialPort:
         response = self.communicate(command)
 
         if response.startswith("ok"):
-            return PlateShuttleSystemStatus.from_hex_string(
-                self.check_prefix_and_strip(response, "ok")
-            )
+            return PlateShuttleSystemStatus.from_hex_string(self.check_prefix_and_strip(response, "ok"))
         if response.startswith("er"):
-            raise SerialCommunicationError.from_error_code(
-                int(self.check_prefix_and_strip(response, "er"), base=16)
-            )
-        raise UnexpectedResponse(
-            f"Expected response like 'ok XX' or 'er XX', got '{response}'"
-        )
+            raise SerialCommunicationError.from_error_code(int(self.check_prefix_and_strip(response, "er"), base=16))
+        raise UnexpectedResponse(f"Expected response like 'ok XX' or 'er XX', got '{response}'")
 
     def issue_status_command(self, command: str) -> str:
         """
@@ -165,9 +157,7 @@ class SerialPort:
         '01'  # full response was 'bs 01'
         """
         if not re.fullmatch("ch:[a-z]{2}.*", command):
-            raise InvalidCommand(
-                f"Expected command like 'ch:xx' or 'ch:xx ...', got '{command}'"
-            )
+            raise InvalidCommand(f"Expected command like 'ch:xx' or 'ch:xx ...', got '{command}'")
 
         return self.check_prefix_and_strip(
             self.communicate(command), expected_prefix=command[3:5]


### PR DESCRIPTION
fixes df-bio/lab-data#253

## Summary by Sourcery

Add a retry mechanism for cytomat status commands when unexpected responses are returned, while keeping existing serial communication behavior unchanged.

Bug Fixes:
- Retry status command queries when an unexpected response is encountered, improving robustness against transient serial communication mismatches.

Enhancements:
- Improve resilience and observability of cytomat status checks by logging unexpected responses and re-attempting the command once.