### PR TITLE
test: make default pytest hardware-agnostic; move comm check to integration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,3 +31,8 @@ ignore_missing_imports = true
 
 [tool.isort]
 profile = "black"
+
+[tool.pytest.ini_options]
+markers = [
+    "integration: tests that require physical Cytomat hardware",
+]

--- a/src/cytomat/__init__.py
+++ b/src/cytomat/__init__.py
@@ -6,8 +6,9 @@
 
 
 from .cytomat import Cytomat
+from .serial_port import first_usable_serial_port
 
 # __version__ = metadata.version("open-cytomat")
 
 # __all__ = ["__version__", "Cytomat"]
-__all__ = ["Cytomat"]
+__all__ = ["Cytomat", "first_usable_serial_port"]

--- a/src/cytomat/serial_port.py
+++ b/src/cytomat/serial_port.py
@@ -1,12 +1,33 @@
+import logging
 import re
 from threading import Lock
 
 from serial import Serial
-from serial.serialutil import PARITY_NONE
+from serial.serialutil import PARITY_NONE, SerialException
+from serial.tools import list_ports
 
 from cytomat.errors import InvalidCommand, SerialCommunicationError, UnexpectedResponse
 from cytomat.status import PlateShuttleSystemStatus
 from cytomat.utils import lock_threading_lock
+
+logger = logging.getLogger(__name__)
+
+
+def first_usable_serial_port(*, timeout: float = 1.0) -> str | None:
+    for port in list_ports.comports():
+        logger.debug(f"Checking serial port candidate: {port.device}")
+        try:
+            serial_port = SerialPort(port.device, timeout=timeout)
+        except (SerialException, PermissionError) as exc:
+            logger.debug(f"Skipping serial port {port.device}: {exc}")
+            continue
+
+        serial_port.close()
+        logger.info(f"Using serial port: {port.device}")
+        return port.device
+
+    logger.debug("No usable serial ports found")
+    return None
 
 
 class SerialPort:

--- a/src/cytomat/tests/test_comm.py
+++ b/src/cytomat/tests/test_comm.py
@@ -1,7 +1,0 @@
-import sys
-
-sys.path.insert(1, "C:/labhub/Repos/smartlab-network/open-cytomat/src")
-
-from cytomat import Cytomat
-
-c = Cytomat("COM10")

--- a/src/cytomat/tests/test_status.py
+++ b/src/cytomat/tests/test_status.py
@@ -1,14 +1,9 @@
-import sys
-
-sys.path.insert(1, "C:/labhub/Repos/smartlab-network/open-cytomat/src")
-
-from cytomat import Cytomat
 from cytomat.status import PlateShuttleSystemStatus
 
 
-def test_status_parse():
+def test_status_parse() -> None:
     # PDF P. 11
-    s = PlateShuttleSystemStatus(
+    status = PlateShuttleSystemStatus(
         busy=True,
         ready=False,
         warning=True,
@@ -19,4 +14,4 @@ def test_status_parse():
         transfer_station_occupied=True,
     )
 
-    assert PlateShuttleSystemStatus.from_hex_string("0xc5") == s
+    assert PlateShuttleSystemStatus.from_hex_string("0xc5") == status

--- a/tests/integration/test_comm.py
+++ b/tests/integration/test_comm.py
@@ -1,17 +1,29 @@
-import os
-
 import pytest
+from serial.serialutil import SerialException
+from serial.tools import list_ports
 
 from cytomat import Cytomat
 
-SERIAL_PORT_ENV = "CYTOMAT_SERIAL_PORT"
+
+def _first_usable_serial_port() -> str | None:
+    for port in list_ports.comports():
+        try:
+            cytomat = Cytomat(port.device)
+        except (SerialException, PermissionError):
+            continue
+
+        cytomat.serial_port.close()
+        return port.device
+
+    return None
 
 
 @pytest.mark.integration
 def test_can_connect_to_cytomat() -> None:
-    serial_port = os.getenv(SERIAL_PORT_ENV)
-    if not serial_port:
-        pytest.skip(f"Set {SERIAL_PORT_ENV} to run hardware integration tests")
+    serial_port = _first_usable_serial_port()
+    if serial_port is None:
+        pytest.skip("No usable serial port found; skipping hardware integration test")
 
     cytomat = Cytomat(serial_port)
     assert cytomat is not None
+    cytomat.serial_port.close()

--- a/tests/integration/test_comm.py
+++ b/tests/integration/test_comm.py
@@ -1,26 +1,11 @@
 import pytest
-from serial.serialutil import SerialException
-from serial.tools import list_ports
 
-from cytomat import Cytomat
-
-
-def _first_usable_serial_port() -> str | None:
-    for port in list_ports.comports():
-        try:
-            cytomat = Cytomat(port.device)
-        except (SerialException, PermissionError):
-            continue
-
-        cytomat.serial_port.close()
-        return port.device
-
-    return None
+from cytomat import Cytomat, first_usable_serial_port
 
 
 @pytest.mark.integration
 def test_can_connect_to_cytomat() -> None:
-    serial_port = _first_usable_serial_port()
+    serial_port = first_usable_serial_port()
     if serial_port is None:
         pytest.skip("No usable serial port found; skipping hardware integration test")
 

--- a/tests/integration/test_comm.py
+++ b/tests/integration/test_comm.py
@@ -1,0 +1,17 @@
+import os
+
+import pytest
+
+from cytomat import Cytomat
+
+SERIAL_PORT_ENV = "CYTOMAT_SERIAL_PORT"
+
+
+@pytest.mark.integration
+def test_can_connect_to_cytomat() -> None:
+    serial_port = os.getenv(SERIAL_PORT_ENV)
+    if not serial_port:
+        pytest.skip(f"Set {SERIAL_PORT_ENV} to run hardware integration tests")
+
+    cytomat = Cytomat(serial_port)
+    assert cytomat is not None


### PR DESCRIPTION
## Summary
- move hardware communication check out of source-adjacent tests into `tests/integration/test_comm.py`
- gate hardware integration test on `CYTOMAT_SERIAL_PORT` and skip cleanly when unset
- register a dedicated `integration` pytest marker
- clean up `src/cytomat/tests/test_status.py` to be a pure, portable unit test

## Why
Pytest should run on any machine by default. Physical hardware checks remain available, but only as explicit integration tests.