### PR TITLE
Add shared lazy serial port resolution with single-port autodetect

### DIFF
--- a/src/cytomat/cli.py
+++ b/src/cytomat/cli.py
@@ -11,6 +11,7 @@ from cytomat.config import default_config_file, load_config, save_config
 from cytomat.cytomat import Cytomat
 from cytomat.maintenance_controller import MaintenanceController
 from cytomat.plate_handler import PlateHandler
+from cytomat.serial_port import usable_serial_ports
 from cytomat.shaker_controller import ShakerController
 
 ControllerSpec = tuple[str, str, str, type[Any]]
@@ -66,20 +67,25 @@ def main() -> None:
     """Command line interface for open-cytomat."""
 
 
+def _connection_options(command: Callable[..., Any]) -> Callable[..., Any]:
+    command = click.option(
+        "--port",
+        type=str,
+        default=None,
+        help="Serial port. If omitted, COM_port is read from --config-file, then auto-detected when exactly one usable port is available.",
+    )(command)
+    command = click.option(
+        "--config-file",
+        type=click.Path(path_type=Path, dir_okay=False),
+        default=default_config_file,
+        show_default=True,
+        help="Path to JSON config file.",
+    )(command)
+    return command
+
+
 @main.group("action", cls=AliasedGroup)
-@click.option(
-    "--port",
-    type=str,
-    default=None,
-    help="Serial port. If omitted, COM_port is read from --config-file.",
-)
-@click.option(
-    "--config-file",
-    type=click.Path(path_type=Path, dir_okay=False),
-    default=default_config_file,
-    show_default=True,
-    help="Path to JSON config file.",
-)
+@_connection_options
 @click.pass_context
 def action(ctx: click.Context, port: str | None, config_file: Path) -> None:
     """Run controller actions or initialize CLI config."""
@@ -111,13 +117,43 @@ action.add_alias("initialize", "init")
 
 
 def _resolve_port(ctx: click.Context) -> str:
-    state = ctx.find_object(dict) or {}
+    state = ctx.find_object(dict)
+    if state is None:
+        raise click.UsageError("Could not resolve action state from Click context")
+
+    cached = state.get("resolved_port")
+    if cached:
+        return cached
+
     explicit_port = state.get("port")
     if explicit_port:
+        state["resolved_port"] = explicit_port
         return explicit_port
 
     config_file = state.get("config_file", default_config_file())
-    return load_config(config_file).com_port
+    configured_port = load_config(config_file).com_port
+    if configured_port:
+        state["resolved_port"] = configured_port
+        return configured_port
+
+    discovered_ports = usable_serial_ports()
+    if len(discovered_ports) == 1:
+        discovered_port = discovered_ports[0]
+        state["resolved_port"] = discovered_port
+        click.echo(f"Auto-detected serial port: {discovered_port}", err=True)
+        return discovered_port
+
+    if not discovered_ports:
+        raise click.UsageError(
+            "No serial port configured and no usable serial ports were auto-detected. "
+            "Pass --port, or set COM_port via `action initialize --com-port ...`."
+        )
+
+    raise click.UsageError(
+        "Multiple usable serial ports found: "
+        f"{', '.join(discovered_ports)}. "
+        "Pass --port, or set COM_port via `action initialize --com-port ...`."
+    )
 
 
 def _resolve_cytomat(ctx: click.Context) -> Cytomat:

--- a/src/cytomat/cli_test.py
+++ b/src/cytomat/cli_test.py
@@ -32,8 +32,11 @@ class FakeShakerController:
 
 
 class FakeCytomat:
+    last_serial_port: str | None = None
+
     def __init__(self, serial_port: str) -> None:
         self.serial_port = serial_port
+        FakeCytomat.last_serial_port = serial_port
         self.plate_handler = FakePlateHandler()
         self.maintenance_controller = FakeMaintenanceController()
         self.climate_controller = FakeClimateController()
@@ -44,6 +47,7 @@ class TestCli:
     @pytest.fixture(autouse=True)
     def setup_mocks(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setattr(cli, "Cytomat", FakeCytomat)
+        FakeCytomat.last_serial_port = None
 
     def test_initialize_writes_config(self, tmp_path: Path) -> None:
         runner = CliRunner()
@@ -84,6 +88,51 @@ class TestCli:
 
         assert result.exit_code == 0
         assert "door-opened" in result.output
+
+    def test_auto_detects_single_usable_port_when_port_not_configured(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        runner = CliRunner()
+        config_file = tmp_path / "config.json"
+        monkeypatch.setattr(cli, "usable_serial_ports", lambda: ["COM42"])
+
+        result = runner.invoke(
+            cli.main,
+            [
+                "action",
+                "--config-file",
+                str(config_file),
+                "plate-handler",
+                "move-plate-from-slot-to-transfer-station",
+                "--slot",
+                "5",
+            ],
+        )
+
+        assert result.exit_code == 0
+        assert "Auto-detected serial port: COM42" in result.output
+        assert FakeCytomat.last_serial_port == "COM42"
+
+    def test_fails_when_multiple_usable_ports_found_without_explicit_configuration(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        runner = CliRunner()
+        config_file = tmp_path / "config.json"
+        monkeypatch.setattr(cli, "usable_serial_ports", lambda: ["COM4", "COM7"])
+
+        result = runner.invoke(
+            cli.main,
+            [
+                "action",
+                "--config-file",
+                str(config_file),
+                "plate-handler",
+                "door-open",
+            ],
+        )
+
+        assert result.exit_code != 0
+        assert "Multiple usable serial ports found: COM4, COM7" in result.output
 
     def test_help_shows_aliases_inline_without_duplicate_entries(self) -> None:
         runner = CliRunner()

--- a/src/cytomat/config.py
+++ b/src/cytomat/config.py
@@ -7,8 +7,8 @@ from pydantic import AliasChoices, BaseModel, ConfigDict, Field
 class CytomatConfig(BaseModel):
     model_config = ConfigDict(extra="ignore", populate_by_name=True)
 
-    com_port: str = Field(
-        default="COM4",
+    com_port: str | None = Field(
+        default=None,
         alias="COM_port",
         validation_alias=AliasChoices("COM_port", "com_port"),
     )
@@ -31,6 +31,6 @@ def save_config(config: CytomatConfig, config_file: Path | None = None) -> Path:
     target = config_file or default_config_file()
     target.parent.mkdir(parents=True, exist_ok=True)
     with target.open("w", encoding="utf-8") as handle:
-        json.dump(config.model_dump(by_alias=True), handle, indent=2)
+        json.dump(config.model_dump(by_alias=True, exclude_none=True), handle, indent=2)
         handle.write("\n")
     return target

--- a/src/cytomat/config_test.py
+++ b/src/cytomat/config_test.py
@@ -5,6 +5,11 @@ from cytomat.config import CytomatConfig, load_config, save_config
 
 
 class TestCytomatConfig:
+    def test_load_returns_empty_config_when_file_missing(self, tmp_path: Path) -> None:
+        config = load_config(tmp_path / "missing.json")
+
+        assert config.com_port is None
+
     def test_load_parses_legacy_com_port_key(self, tmp_path: Path) -> None:
         config_file = tmp_path / "legacy.json"
         config_file.write_text(
@@ -23,3 +28,11 @@ class TestCytomatConfig:
 
         payload = json.loads(config_file.read_text(encoding="utf-8"))
         assert payload == {"COM_port": "COM7"}
+
+    def test_save_omits_com_port_when_unset(self, tmp_path: Path) -> None:
+        config_file = tmp_path / "config.json"
+
+        save_config(CytomatConfig(), config_file)
+
+        payload = json.loads(config_file.read_text(encoding="utf-8"))
+        assert payload == {}

--- a/src/cytomat/serial_port.py
+++ b/src/cytomat/serial_port.py
@@ -13,7 +13,8 @@ from cytomat.utils import lock_threading_lock
 logger = logging.getLogger(__name__)
 
 
-def first_usable_serial_port(*, timeout: float = 1.0) -> str | None:
+def usable_serial_ports(*, timeout: float = 1.0) -> list[str]:
+    usable_ports: list[str] = []
     for port in list_ports.comports():
         logger.debug(f"Checking serial port candidate: {port.device}")
         try:
@@ -23,11 +24,19 @@ def first_usable_serial_port(*, timeout: float = 1.0) -> str | None:
             continue
 
         serial_port.close()
-        logger.info(f"Using serial port: {port.device}")
-        return port.device
+        usable_ports.append(port.device)
 
-    logger.debug("No usable serial ports found")
-    return None
+    if usable_ports:
+        logger.info(f"Usable serial ports: {', '.join(usable_ports)}")
+    else:
+        logger.debug("No usable serial ports found")
+
+    return usable_ports
+
+
+def first_usable_serial_port(*, timeout: float = 1.0) -> str | None:
+    ports = usable_serial_ports(timeout=timeout)
+    return ports[0] if ports else None
 
 
 class SerialPort:


### PR DESCRIPTION
## Summary
- make serial port resolution lazy and shared in the CLI context
- resolve port in order: `--port` -> `COM_port` in config -> auto-detect when exactly one usable serial port exists
- fail clearly when zero or multiple usable ports are found without explicit config
- make config `COM_port` optional (no hardcoded default)

## Implementation notes
- add reusable connection options decorator for command groups to support future groups with one shared pattern
- add `usable_serial_ports()` and keep `first_usable_serial_port()` as a thin wrapper
- cache resolved port in click context so it is computed once

## Tests
- `uv run pytest src/cytomat/cli_test.py src/cytomat/config_test.py`
- result: 10 passed