### PR TITLE
refactor: migrate status models to pydantic and add Cytomat.status

### DIFF
--- a/src/cytomat/cytomat.py
+++ b/src/cytomat/cytomat.py
@@ -12,9 +12,9 @@ from cytomat.status import (
     ErrorStatus,
     OverviewStatus,
     PlateShuttleSystemStatus,
+    Status,
     WarningStatus,
 )
-from cytomat.utils import enum_to_dict
 
 
 class Cytomat:
@@ -50,40 +50,46 @@ class Cytomat:
         self.shaker_controller = ShakerController(self.serial_port)
 
     @property
-    def overview_status(self) -> OverviewStatus:
-        """Status overview"""
-        return OverviewStatus.from_hex_string(
-            self.serial_port.issue_status_command("ch:bs")
+    def status(self) -> Status:
+        """Bundled device status."""
+        overview_byte = self.serial_port.issue_status_command("ch:bs")
+        action_byte = self.serial_port.issue_status_command("ch:ba")
+        error_byte = self.serial_port.issue_status_command("ch:be")
+        warning_byte = self.serial_port.issue_status_command("ch:bw")
+
+        return Status(
+            plate_shuttle_system=PlateShuttleSystemStatus.from_hex_string(overview_byte),
+            overview=OverviewStatus.from_hex_string(overview_byte),
+            action=ActionStatus.from_hex_string(action_byte),
+            error=ErrorStatus.from_hex_string(error_byte),
+            warning=WarningStatus.from_hex_string(warning_byte),
         )
+
+    @property
+    def overview_status(self) -> OverviewStatus:
+        """Status overview."""
+        return OverviewStatus.from_hex_string(self.serial_port.issue_status_command("ch:bs"))
 
     @property
     def action_status(self) -> ActionStatus:
-        """Action status"""
-        return ActionStatus.from_hex_string(
-            self.serial_port.issue_status_command("ch:ba")
-        )
+        """Action status."""
+        return ActionStatus.from_hex_string(self.serial_port.issue_status_command("ch:ba"))
 
     @property
     def error_status(self) -> ErrorStatus:
-        """Error status"""
-        return enum_to_dict(ErrorStatus)[
-            int(self.serial_port.issue_status_command("ch:be"), base=16)
-        ]
+        """Error status."""
+        return ErrorStatus.from_hex_string(self.serial_port.issue_status_command("ch:be"))
 
     @property
     def warning_status(self) -> WarningStatus:
-        """Warning status"""
-        return enum_to_dict(WarningStatus)[
-            int(self.serial_port.issue_status_command("ch:bw"), base=16)
-        ]
+        """Warning status."""
+        return WarningStatus.from_hex_string(self.serial_port.issue_status_command("ch:bw"))
 
     def reset_error_register(self) -> PlateShuttleSystemStatus:
-        """Reset the error register"""
+        """Reset the error register."""
         return self.serial_port.issue_action_command("rs:be")
 
-    def wait_until_not_busy(
-        self, timeout: float, poll_interval: float = 0.5
-    ) -> OverviewStatus:
+    def wait_until_not_busy(self, timeout: float, poll_interval: float = 0.5) -> OverviewStatus:
         """
         Block the current thread until the device is not busy anymore.
 

--- a/src/cytomat/status.py
+++ b/src/cytomat/status.py
@@ -1,14 +1,13 @@
 from __future__ import annotations
 
 from enum import IntEnum
-from typing import NamedTuple
 
-from cytomat.utils import enum_to_dict, int_to_bits
+from pydantic import BaseModel
 
-# TODO: unify status decoding
+from cytomat.utils import int_to_bits
 
 
-class PlateShuttleSystemStatus(NamedTuple):
+class PlateShuttleSystemStatus(BaseModel):
     transfer_station_occupied: bool
     device_door_open: bool
     transfer_door_open: bool
@@ -20,11 +19,21 @@ class PlateShuttleSystemStatus(NamedTuple):
 
     @classmethod
     def from_hex_string(cls, hex_byte: str) -> PlateShuttleSystemStatus:
-        """Create an instance from the hex string (e.g. ``'F1'``)"""
-        return cls(*int_to_bits(int(hex_byte, base=16), n_bits=8))
+        """Create an instance from the hex string (e.g. ``'F1'``)."""
+        bits = int_to_bits(int(hex_byte, base=16), n_bits=8)
+        return cls(
+            transfer_station_occupied=bits[0],
+            device_door_open=bits[1],
+            transfer_door_open=bits[2],
+            shovel_occupied=bits[3],
+            error=bits[4],
+            warning=bits[5],
+            ready=bits[6],
+            busy=bits[7],
+        )
 
 
-class OverviewStatus(NamedTuple):
+class OverviewStatus(BaseModel):
     command_in_process: bool
     command_executed_device_busy: bool
     warning_pending: bool
@@ -71,6 +80,11 @@ class ErrorStatus(IntEnum):
     ShakerClampNotClosed = 0x14
     Critical = 0xFF
 
+    @classmethod
+    def from_hex_string(cls, hex_byte: str) -> ErrorStatus:
+        """Map a status hex byte (e.g. ``'0A'``) to a typed error status."""
+        return cls(int(hex_byte, base=16))
+
 
 class WarningStatus(IntEnum):
     NoWarning = 0x00
@@ -84,6 +98,11 @@ class WarningStatus(IntEnum):
     ShovelNotRetracted = 0x08
     InitialisingDueToOpenedDeviceDoor = 0x09
     TransferStationNotRotated = 0x0C
+
+    @classmethod
+    def from_hex_string(cls, hex_byte: str) -> WarningStatus:
+        """Map a status hex byte (e.g. ``'09'``) to a typed warning status."""
+        return cls(int(hex_byte, base=16))
 
 
 class ActionType(IntEnum):
@@ -112,11 +131,9 @@ class ActionType(IntEnum):
     MoveToBarcodeReader = 0x16
     CheckHandlerAtBarcodeReader = 0x17
     ReadBarcode = 0x18
-    UnknownX1b = 0x1b
-    UnknownX1c = 0x1c
-    """Assumptions:
-    0x1c is related to extending or retracting the shovel
-    """
+    UnknownX1b = 0x1B
+    UnknownX1c = 0x1C
+
 
 class ActionTarget(IntEnum):
     InitPosition = 1
@@ -125,20 +142,20 @@ class ActionTarget(IntEnum):
     TransferStation = 4
 
 
-class ActionStatus(NamedTuple):
+class ActionStatus(BaseModel):
     type: ActionType
     target: ActionTarget
 
     @classmethod
     def from_hex_string(cls, hex_byte: str) -> ActionStatus:
         """Create an instance from the hex string (e.g. ``'F1'``)."""
-        num = int(hex_byte, base=16)
-        action_target = enum_to_dict(ActionTarget)[(num & 0b11100000) >> 5]
-        action_type = enum_to_dict(ActionType)[num & 0b00011111]
-        return ActionStatus(action_type, action_target)
+        value = int(hex_byte, base=16)
+        target = ActionTarget((value & 0b11100000) >> 5)
+        action_type = ActionType(value & 0b00011111)
+        return cls(type=action_type, target=target)
 
 
-class SwapStationStatus(NamedTuple):
+class SwapStationStatus(BaseModel):
     position1_at_door: bool
     occupied_at_door: bool
     occupied_at_user: bool
@@ -146,8 +163,16 @@ class SwapStationStatus(NamedTuple):
     @classmethod
     def from_response_string(cls, response: str) -> SwapStationStatus:
         """Create an instance from the response string (e.g. ``'111'``)."""
-        return SwapStationStatus(
+        return cls(
             position1_at_door=response[0] == "1",
             occupied_at_door=response[1] == "1",
             occupied_at_user=response[2] == "1",
         )
+
+
+class Status(BaseModel):
+    plate_shuttle_system: PlateShuttleSystemStatus
+    overview: OverviewStatus
+    action: ActionStatus
+    error: ErrorStatus
+    warning: WarningStatus

--- a/src/cytomat/status.py
+++ b/src/cytomat/status.py
@@ -36,7 +36,7 @@ class OverviewStatus(NamedTuple):
 
     @classmethod
     def from_hex_string(cls, hex_byte: str) -> OverviewStatus:
-        """Create an instance from the hex string (e.g. ``'F1'``)"""
+        """Create an instance from the hex string (e.g. ``'F1'``)."""
         value = int(hex_byte, base=16)
         return cls(
             command_in_process=bool(value & 0x01),
@@ -131,7 +131,7 @@ class ActionStatus(NamedTuple):
 
     @classmethod
     def from_hex_string(cls, hex_byte: str) -> ActionStatus:
-        """Create an instance from the hex string (e.g. ``'F1'``)"""
+        """Create an instance from the hex string (e.g. ``'F1'``)."""
         num = int(hex_byte, base=16)
         action_target = enum_to_dict(ActionTarget)[(num & 0b11100000) >> 5]
         action_type = enum_to_dict(ActionType)[num & 0b00011111]
@@ -145,7 +145,7 @@ class SwapStationStatus(NamedTuple):
 
     @classmethod
     def from_response_string(cls, response: str) -> SwapStationStatus:
-        """Create an instance from the response string (e.g. ``'111'``)"""
+        """Create an instance from the response string (e.g. ``'111'``)."""
         return SwapStationStatus(
             position1_at_door=response[0] == "1",
             occupied_at_door=response[1] == "1",

--- a/src/cytomat/status_test.py
+++ b/src/cytomat/status_test.py
@@ -1,0 +1,37 @@
+import pytest
+
+from cytomat.status import ErrorStatus, WarningStatus
+
+
+class TestErrorStatus:
+    @pytest.mark.parametrize(
+        "hex_byte,expected",
+        [
+            ("00", ErrorStatus.NoError),
+            ("01", ErrorStatus.MotorCommunicationDisrupted),
+            ("FF", ErrorStatus.Critical),
+        ],
+    )
+    def test_maps_known_hex_codes(self, hex_byte: str, expected: ErrorStatus) -> None:
+        assert ErrorStatus.from_hex_string(hex_byte) is expected
+
+    def test_raises_for_unknown_hex_code(self) -> None:
+        with pytest.raises(ValueError):
+            ErrorStatus.from_hex_string("11")
+
+
+class TestWarningStatus:
+    @pytest.mark.parametrize(
+        "hex_byte,expected",
+        [
+            ("00", WarningStatus.NoWarning),
+            ("09", WarningStatus.InitialisingDueToOpenedDeviceDoor),
+            ("0C", WarningStatus.TransferStationNotRotated),
+        ],
+    )
+    def test_maps_known_hex_codes(self, hex_byte: str, expected: WarningStatus) -> None:
+        assert WarningStatus.from_hex_string(hex_byte) is expected
+
+    def test_raises_for_unknown_hex_code(self) -> None:
+        with pytest.raises(ValueError):
+            WarningStatus.from_hex_string("0A")


### PR DESCRIPTION
## Summary
- refactor status data structures in `src/cytomat/status.py` from legacy `NamedTuple` to `pydantic.BaseModel`
- add aggregate `Status` model bundling `plate_shuttle_system`, `overview`, `action`, `error`, and `warning`
- expose bundled status on `Cytomat` via new `status` property in `src/cytomat/cytomat.py`
- unify error/warning decoding through `ErrorStatus.from_hex_string(...)` and `WarningStatus.from_hex_string(...)`
- add focused unit tests for enum mapping and unknown-code behavior in `src/cytomat/status_test.py`

## Notes
- `Cytomat.status` reads each status command once and reuses the `ch:bs` byte for both `overview` and `plate_shuttle_system` to avoid divergence.
- Existing individual properties (`overview_status`, `action_status`, `error_status`, `warning_status`) are kept for compatibility.

## Validation
- `uv run pytest src/cytomat/status_test.py`
- `uv run pytest`