### PR TITLE
ci: add GitHub-hosted Actions workflow and local lint/test conventions

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,4 @@
+[flake8]
+max-line-length = 88
+extend-ignore = E203, W503
+exclude = .git,__pycache__,.venv,build,dist

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,126 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  format-black:
+    name: format (black --check)
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+
+      - name: setup python
+        uses: actions/setup-python@v5
+        with:
+          python-version-file: .python-version
+
+      - name: setup uv
+        uses: astral-sh/setup-uv@v5
+
+      - name: install deps
+        run: uv sync --dev
+
+      - name: black check
+        run: uv run python -m black --check .
+
+  imports-isort:
+    name: imports (isort --check-only)
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+
+      - name: setup python
+        uses: actions/setup-python@v5
+        with:
+          python-version-file: .python-version
+
+      - name: setup uv
+        uses: astral-sh/setup-uv@v5
+
+      - name: install deps
+        run: uv sync --dev
+
+      - name: isort check
+        run: uv run python -m isort --check-only .
+
+  lint-flake8:
+    name: lint (flake8)
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+
+      - name: setup python
+        uses: actions/setup-python@v5
+        with:
+          python-version-file: .python-version
+
+      - name: setup uv
+        uses: astral-sh/setup-uv@v5
+
+      - name: install deps
+        run: uv sync --dev
+
+      - name: flake8
+        run: uv run python -m flake8 src tests
+
+  typecheck-mypy:
+    name: typecheck (mypy)
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+
+      - name: setup python
+        uses: actions/setup-python@v5
+        with:
+          python-version-file: .python-version
+
+      - name: setup uv
+        uses: astral-sh/setup-uv@v5
+
+      - name: install deps
+        run: uv sync --dev
+
+      - name: mypy
+        run: uv run python -m mypy src tests
+
+  test-pytest:
+    name: tests (pytest)
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+
+      - name: setup python
+        uses: actions/setup-python@v5
+        with:
+          python-version-file: .python-version
+
+      - name: setup uv
+        uses: astral-sh/setup-uv@v5
+
+      - name: install deps
+        run: uv sync --dev
+
+      - name: pytest
+        run: uv run python -m pytest -m "not integration"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,27 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: check-yaml
+      - id: end-of-file-fixer
+      - id: trailing-whitespace
+
+  - repo: https://github.com/pycqa/isort
+    rev: 5.13.2
+    hooks:
+      - id: isort
+
+  - repo: https://github.com/psf/black
+    rev: 24.10.0
+    hooks:
+      - id: black
+
+  - repo: https://github.com/pycqa/flake8
+    rev: 7.1.1
+    hooks:
+      - id: flake8
+
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v1.14.1
+    hooks:
+      - id: mypy

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,11 @@ open-cytomat = "cytomat.cli:main"
 
 [dependency-groups]
 dev = [
+    "black>=24.10.0,<25",
+    "flake8>=7.1.1,<8",
+    "isort>=5.13.2,<6",
     "mypy>=1.4.1,<2",
+    "pre-commit>=4.0.1,<5",
     "pytest>=7.4.0,<8",
 ]
 
@@ -47,7 +51,11 @@ click = "^8.1.7"
 pydantic = "^2.9.2"
 
 [tool.poetry.group.dev.dependencies]
+black = "^24.10.0"
+flake8 = "^7.1.1"
+isort = "^5.13.2"
 mypy = "^1.4.1"
+pre-commit = "^4.0.1"
 pytest = "^7.4.0"
 
 [tool.poetry.scripts]
@@ -58,6 +66,7 @@ requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"
 
 [[tool.mypy.overrides]]
+module = ["serial", "serial.*"]
 ignore_missing_imports = true
 
 [tool.isort]

--- a/run-checks
+++ b/run-checks
@@ -2,8 +2,8 @@
 
 set -ex
 
-python -m isort --check-only .
-python -m black --check .
-python -m pflake8 .
-python -m mypy .
+uv run python -m isort --check-only .
+uv run python -m black --check .
+uv run python -m flake8 src tests
+uv run python -m mypy src tests
 make -C docs/ clean html

--- a/run-formatting
+++ b/run-formatting
@@ -2,9 +2,9 @@
 
 set -ex
 
-python -m isort .
-python -m black .
-python -m isort --check-only .
-python -m black --check .
-python -m pflake8 .
-python -m mypy .
+uv run python -m isort .
+uv run python -m black .
+uv run python -m isort --check-only .
+uv run python -m black --check .
+uv run python -m flake8 src tests
+uv run python -m mypy src tests


### PR DESCRIPTION
## Summary
Add baseline GitHub Actions CI and local code-quality conventions.

## Changes
- Add `.github/workflows/ci.yml` using **GitHub-hosted runners** (`ubuntu-latest`) with one check per job:
  - `black --check`
  - `isort --check-only`
  - `flake8`
  - `mypy`
  - `pytest -m "not integration"`
- Add `.pre-commit-config.yaml` for local hook alignment.
- Add `.flake8` for lint defaults and path exclusions.
- Update `pyproject.toml` dev tooling dependencies and mypy override config.
- Update `run-checks` and `run-formatting` to use `uv run` and scoped lint/typecheck targets.

## Notes
This PR bootstraps CI/conventions and intentionally does **not** clean up all pre-existing lint/type issues. CI may fail on legacy debt, which is acceptable for this step.

## Validation
- `uv run python -m pytest -m "not integration"` ✅ (19 passed, 1 deselected)
